### PR TITLE
Remove blue inset box-shadow from red modal button

### DIFF
--- a/Flat Remix/gnome-shell/gnome-shell.css
+++ b/Flat Remix/gnome-shell/gnome-shell.css
@@ -186,7 +186,8 @@ StScrollBar {
 		padding: 0;
 		border: 0;
 		border-radius: 0;
-		background-color: black
+		background-color: black;
+		box-shadow: inset 0 0 black;
 	}
 
 .button-dialog-button-box {


### PR DESCRIPTION
Remove the tiny blue inner border from the red modal buttons for logout and shutdown so that the button appears to be solid red edge to edge.